### PR TITLE
Remove section on key size

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,6 @@
                     <ol v-show="showArea.preMove">
                         <li>
                             <h3>Select an SSL certificate</h3>
-                            <p>As most SSL providers now supply a 2048-bit key or higher by default, your first question really is, what sort of certificate do you want?</p>
                             <p>There are 3 main types of certificates you can choose from for your site:</p>
                             <ul>
                                 <li>Domain Validation <em>(DV)</em>


### PR DESCRIPTION
CAs don't supply private keys. They can be generated by a tool. Most users should just use the default size.